### PR TITLE
Added relativeTo query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ loaders: [
 
 where `id` is the id of your overall wrapper element.
 
+### RelativeTo and Prefix
+
+You can set the base path of your templates using the `relativeTo` parameters. `relativeTo` is used
+to strip a matching prefix from the absolute path of the input html file.
+
+The path up to and including the first `relativeTo` match is stripped, e.g.
+
+``` javascript
+require('!ngtemplate?relativeTo=/src/!html!/test/src/test.svg');
+// c.put('test.svg', ...)
+```
+
+To match the from the start of the absolute path prefix a '//', e.g.
+
+``` javascript
+require('!ngtemplate?relativeTo=//Users/felixjung/project/test/!html!/test/src/test.svg');
+// c.put('src/test.svg', ...)
+```
+
 ## Planned features
 - [ ] Support for chaining with other loaders such as the [image-webpack-loader](https://github.com/tcoopman/image-webpack-loader).
 - [ ] Write tests.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ require('!ngtemplate?relativeTo=//Users/felixjung/project/test/!html!/test/src/t
 - [ 2015-08-12 | 0.1.0 ) - Initial release
 
 ## Credit
-This is my first loader for webpack. I took a lot of ideas from the [file-loader](https://github.com/webpack/file-loader) and the [style-loaders](https://github.com/webpack/style-loader).
+This is my first loader for webpack. I took a lot of ideas from the [file-loader](https://github.com/webpack/file-loader) and the [style-loaders](https://github.com/webpack/style-loader). The relativeTo feature was taken from [ngtemplate-loader](https://github.com/WearyMonkey/ngtemplate-loader)
 
 ## License
 MIT ([http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php))

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ require('!ngtemplate?relativeTo=//Users/felixjung/project/test/!html!/test/src/t
 - [ 2015-08-12 | 0.1.0 ) - Initial release
 
 ## Credit
-This is my first loader for webpack. I took a lot of ideas from the [file-loader](https://github.com/webpack/file-loader) and the [style-loaders](https://github.com/webpack/style-loader). The relativeTo feature was taken from [ngtemplate-loader](https://github.com/WearyMonkey/ngtemplate-loader)
+This is my first loader for webpack. I took a lot of ideas from the [file-loader](https://github.com/webpack/file-loader) and the [style-loaders](https://github.com/webpack/style-loader). The `relativeTo` feature was taken from [ngtemplate-loader](https://github.com/WearyMonkey/ngtemplate-loader)
 
 ## License
 MIT ([http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php))

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ require('!ngtemplate?relativeTo=//Users/felixjung/project/test/!html!/test/src/t
 - [ 2015-08-12 | 0.1.0 ) - Initial release
 
 ## Credit
-This is my first loader for webpack. I took a lot of ideas from the [file-loader](https://github.com/webpack/file-loader) and the [style-loaders](https://github.com/webpack/style-loader). The `relativeTo` feature was taken from [ngtemplate-loader](https://github.com/WearyMonkey/ngtemplate-loader)
+This is my first loader for webpack. I took a lot of ideas from the [file-loader](https://github.com/webpack/file-loader) and the [style-loaders](https://github.com/webpack/style-loader). The `relativeTo` feature was taken from [ngtemplate-loader](https://github.com/WearyMonkey/ngtemplate-loader).
 
 ## License
 MIT ([http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php))

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ module.exports = function(content) {
   var resource = this.resource;
   var pathSepRegex = new RegExp(escapeRegExp(path.sep), 'g');
 
-  // if a unix path starts with // we treat is as an absolute path e.g. //Users/wearymonkey
-  // if we're on windows, then we ignore the / prefix as windows absolute paths are unique anyway e.g. C:\Users\wearymonkey
+  // if a unix path starts with // we treat is as an absolute path e.g. //Users/felixjung
+  // if we're on windows, then we ignore the / prefix as windows absolute paths are unique anyway e.g. C:\Users\felixjung
   if (relativeTo[0] == '/') {
       if (path.sep == '\\') { // we're on windows
           relativeTo = relativeTo.substring(1);

--- a/index.js
+++ b/index.js
@@ -10,8 +10,42 @@ module.exports = function(content) {
   this.cacheable && this.cacheable();
 
   // Parse query into options and add resourcePath to options
-  var options = utils.parseQuery(this.query);
-  options.resourcePath = this.resourcePath;
+  var query = utils.parseQuery(this.query);
+  var options = {
+      resourcePath: this.resourcePath
+  };
+
+  // relativeTo from https://github.com/WearyMonkey/ngtemplate-loader
+  var relativeTo = query.relativeTo || '';
+  var absolute = false;
+  var pathSep = query.pathSep || '/';
+  var resource = this.resource;
+  var pathSepRegex = new RegExp(escapeRegExp(path.sep), 'g');
+
+  // if a unix path starts with // we treat is as an absolute path e.g. //Users/wearymonkey
+  // if we're on windows, then we ignore the / prefix as windows absolute paths are unique anyway e.g. C:\Users\wearymonkey
+  if (relativeTo[0] == '/') {
+      if (path.sep == '\\') { // we're on windows
+          relativeTo = relativeTo.substring(1);
+      } else if (relativeTo[1] == '/') {
+          absolute = true;
+          relativeTo = relativeTo.substring(1);
+      }
+  }
+
+  // normalise the path separators
+  if (path.sep != pathSep) {
+      relativeTo = relativeTo.replace(pathSepRegex, pathSep);
+      resource = resource.replace(pathSepRegex, pathSep)
+  }
+
+  var relativeToIndex = resource.indexOf(relativeTo);
+  if (relativeToIndex === -1 || (absolute && relativeToIndex !== 0)) {
+      throw 'The path for file doesn\'t contain relativeTo param';
+  }
+
+  // reassign resource path
+  options.resourcePath = resource.slice(relativeToIndex + relativeTo.length); // get the base path
 
   var loaderCode = [
     '// inline-loader: inserts the content of a resource into the DOM.',
@@ -26,4 +60,9 @@ module.exports = function(content) {
   ].join('\n');
 
   return loaderCode;
+
+  // source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Using_Special_Characters
+  function escapeRegExp(string) {
+      return string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-loader",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "A webpack loader that wraps the content of a resource inside a <div> element and inserts it into the DOM.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi Felix, excellent work on this loader so far!

The current version of the loader will expose full file paths inside of the bundle. Eg. "C:\Users\felixjung\src\my\svg\file.svg" will get added inside of the bundle. This fixes that by using `relativeTo` taken from https://github.com/WearyMonkey/ngtemplate-loader I've also updated the version number and readme accordingly.

This was partially test on Windows.
