### PR TITLE
Don't expose absolute asset paths in modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /*
-	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author Felix Jung @feju
+  MIT License http://www.opensource.org/licenses/mit-license.php
+  Author Felix Jung @feju
 */
 
 var path = require('path');
@@ -11,7 +11,7 @@ module.exports = function(content) {
 
   // Parse query into options and add resourcePath to options
   var options = utils.parseQuery(this.query);
-  options.resourcePath = this.resourcePath;
+  options.resourcePath = utils.stringifyRequest(this, this.resourcePath);
 
   var loaderCode = [
     '// inline-loader: inserts the content of a resource into the DOM.',


### PR DESCRIPTION
This PR addresses an issue brought up by @MikaelLambert in #2. Previously, assets included by inline-loader would have their absolute paths on the webserver exposed in the webpack modules. By applying `utils.stringifyRequest()` to the resource path before setting it in the options object, the absolute paths get converted to relative ones.
